### PR TITLE
Feature/cookie support

### DIFF
--- a/bin/atlas-jira-cli
+++ b/bin/atlas-jira-cli
@@ -88,6 +88,9 @@ def parse_opts
     o.separator "Authentication:"
     o.separator ""
     o.separator "    By default, atlas-jira-cli will prompt you for a username and password.  You may also store your password (and username, endpoint, and cacert) in ~/.atlas-cli-rc."
+    o.on('--stdin-auth', 'Read credentials from stdin, of form "username=foo\npassword=bar\n"') do |ct|
+      options.update(Hash[*STDIN.read.split(/[=\n]/)].deep_symbolize_keys)
+    end
     o.separator ""
 
     o.separator "Options:"


### PR DESCRIPTION
This provides an ability to read credentials from stdin.  It also has a patch to mention ~/.atlas-cli-rc in lieu of ~/.netrc, which I'm not sure if it's what you want, but at least mentions the alternate location that you pointed me at.
