### PR TITLE
Fix wrong number of arguments error

### DIFF
--- a/lib/atlassian/rest/client.rb
+++ b/lib/atlassian/rest/client.rb
@@ -14,15 +14,7 @@ module Atlassian
         attr_accessor :message
         attr_accessor :status
 
-        def initialize(status)
-          initialize(status, nil, nil)
-        end
-
-        def initialize(status, content)
-          initialize(status, content, nil)
-        end
-
-        def initialize(status, content, message)
+        def initialize(status, content = nil, message = nil)
           @status = status
           @content = content
           @message = message


### PR DESCRIPTION
Fixes the following error when incorrect username and password are given

```
/usr/local/rvm/gems/ruby-2.2.1/bundler/gems/atlassian-cli-c4928af9b506/lib/atlassian/rest/client.rb:25:in `initialize': wrong number of arguments (1 for 3) (ArgumentError)
	from /usr/local/rvm/gems/ruby-2.2.1/bundler/gems/atlassian-cli-c4928af9b506/lib/atlassian/rest/client.rb:162:in `new'
	from /usr/local/rvm/gems/ruby-2.2.1/bundler/gems/atlassian-cli-c4928af9b506/lib/atlassian/rest/client.rb:162:in `ensure_logged_in'
	from /usr/local/rvm/gems/ruby-2.2.1/bundler/gems/atlassian-cli-c4928af9b506/lib/atlassian/rest/jira/client.rb:40:in `get_issue_by_key'
	from /usr/local/rvm/gems/ruby-2.2.1/bundler/gems/atlassian-cli-c4928af9b506/bin/atlas-jira-cli:394:in `get_issue_from_key_or_id'
	from /usr/local/rvm/gems/ruby-2.2.1/bundler/gems/atlassian-cli-c4928af9b506/bin/atlas-jira-cli:465:in `<top (required)>'
	from /usr/local/rvm/gems/ruby-2.2.1/bin/atlas-jira-cli:23:in `load'
	from /usr/local/rvm/gems/ruby-2.2.1/bin/atlas-jira-cli:23:in `<main>'
	from /usr/local/rvm/gems/ruby-2.2.1/bin/ruby_executable_hooks:15:in `eval'
	from /usr/local/rvm/gems/ruby-2.2.1/bin/ruby_executable_hooks:15:in `<main>'
```

The output instead with the fix is

```
Got error: Atlassian::Rest::HttpStatus::HttpClientError(Unable to authenticate):
	Message: ''
	Content: ''
nil
```